### PR TITLE
feat(translations): add babele support

### DIFF
--- a/src/aa-classes/aaAutorecFunctions.js
+++ b/src/aa-classes/aaAutorecFunctions.js
@@ -10,6 +10,14 @@ export class AAAutorecFunctions {
         return newName;
     }
 
+    static getRealName(name, item) {
+        if(!name || !item) { return; }
+
+        if(!game.modules.has('babele')) return name;
+
+        return item.flags.babele.originalName || name;
+    }
+
     static sortAndFilterMenus(menus) {
 
         let combinedMenus = [...menus.melee, ...menus.range, ...menus.ontoken,

--- a/src/aa-classes/aaAutorecFunctions.js
+++ b/src/aa-classes/aaAutorecFunctions.js
@@ -15,7 +15,7 @@ export class AAAutorecFunctions {
 
         if(!game.modules.has('babele')) return name;
 
-        return item.flags.babele.originalName || name;
+        return item.getFlag('babele', 'originalName') || name;
     }
 
     static sortAndFilterMenus(menus) {

--- a/src/formApps/_ActiveEffects/components/category/CategoryControl.svelte
+++ b/src/formApps/_ActiveEffects/components/category/CategoryControl.svelte
@@ -69,7 +69,7 @@
   }
 
   //let itemName = item.label;
-  const realName = AAAutorecFunctions.getRealName($animation.label, item);
+  let realName = AAAutorecFunctions.getRealName($animation.label, item);
   //Check the Autorec Menu for a matching Section
   $: isInAutorec = AAAutorecFunctions.singleMenuSearch(aefxMenu, AAAutorecFunctions.rinseName(realName), realName);
 

--- a/src/formApps/_ActiveEffects/components/category/CategoryControl.svelte
+++ b/src/formApps/_ActiveEffects/components/category/CategoryControl.svelte
@@ -69,8 +69,9 @@
   }
 
   //let itemName = item.label;
+  const realName = AAAutorecFunctions.getRealName($animation.label, item);
   //Check the Autorec Menu for a matching Section
-  $: isInAutorec = AAAutorecFunctions.singleMenuSearch(aefxMenu, AAAutorecFunctions.rinseName($animation.label), $animation.label);
+  $: isInAutorec = AAAutorecFunctions.singleMenuSearch(aefxMenu, AAAutorecFunctions.rinseName(realName), realName);
 
   let menu = isInAutorec
     ? game.i18n.localize(`autoanimations.animTypes.${isInAutorec.menu}`)

--- a/src/formApps/_ItemMenu/components/category/CategoryControl.svelte
+++ b/src/formApps/_ItemMenu/components/category/CategoryControl.svelte
@@ -58,7 +58,7 @@
 
   //Check the Autorec Menu for a matching Section
   let filteredSettings = AAAutorecFunctions.sortAndFilterMenus(autorecSettings)
-  const realName = AAAutorecFunctions.getRealName($animation.label, item);
+  let realName = AAAutorecFunctions.getRealName($animation.label, item);
   $: isInAutorec = AAAutorecFunctions.allMenuSearch(filteredSettings, AAAutorecFunctions.rinseName(realName), realName);
   //let filteredSettings = AAAutorecFunctions.sortAndFilterAllMenus(autorecSettings)
   $: isInAEAutorec =  AAAutorecFunctions.singleMenuSearch(autorecSettings.aefx, AAAutorecFunctions.rinseName($animation.label), $animation.label);

--- a/src/formApps/_ItemMenu/components/category/CategoryControl.svelte
+++ b/src/formApps/_ItemMenu/components/category/CategoryControl.svelte
@@ -58,7 +58,8 @@
 
   //Check the Autorec Menu for a matching Section
   let filteredSettings = AAAutorecFunctions.sortAndFilterMenus(autorecSettings)
-  $: isInAutorec = AAAutorecFunctions.allMenuSearch(filteredSettings, AAAutorecFunctions.rinseName($animation.label), $animation.label);
+  const realName = AAAutorecFunctions.getRealName($animation.label, item);
+  $: isInAutorec = AAAutorecFunctions.allMenuSearch(filteredSettings, AAAutorecFunctions.rinseName(realName), realName);
   //let filteredSettings = AAAutorecFunctions.sortAndFilterAllMenus(autorecSettings)
   $: isInAEAutorec =  AAAutorecFunctions.singleMenuSearch(autorecSettings.aefx, AAAutorecFunctions.rinseName($animation.label), $animation.label);
 

--- a/src/system-handlers/findAnimation.js
+++ b/src/system-handlers/findAnimation.js
@@ -4,15 +4,16 @@ import { debug } from "../constants/constants.js";
 
 export async function handleItem(data) {
 
+    console.error(handleItem);
     // GTFO if no Item was sent
     if (!data.item) { return; };
 
     const item = data.item;
-    const itemName = item.name ?? item.label;
+    const itemName = AAAutorecFunctions.getRealName(item.name ?? item.label, item);
     const rinsedItemName = itemName ? AAAutorecFunctions.rinseName(itemName) : "noitem";
 
     const ammoItem = data.ammoItem;
-    const rinsedAmmoName = ammoItem?.name ? AAAutorecFunctions.rinseName(ammoItem.name) : "";
+    const rinsedAmmoName = ammoItem?.name ? AAAutorecFunctions.rinseName(AAAutorecFunctions.getRealName(ammoItem.name, ammoItem)) : "";
 
     // Send Item thru Flag Merge
     const itemFlags = await flagMigrations.handle(data.item, {activeEffect: data.activeEffect}) || {};

--- a/src/system-handlers/findAnimation.js
+++ b/src/system-handlers/findAnimation.js
@@ -4,7 +4,6 @@ import { debug } from "../constants/constants.js";
 
 export async function handleItem(data) {
 
-    console.error(handleItem);
     // GTFO if no Item was sent
     if (!data.item) { return; };
 


### PR DESCRIPTION
Hi

As you can see here https://github.com/MrVauxs/dnd5e-animations/issues/36, being able to map animations to items without having the hassle to rename imports is awaited

This PR adds support for babele when trying to match items to animations

Let me know what you think