### PR TITLE
dnd5e: add activity-level animation config support (ammo > activity > item)

### DIFF
--- a/src/formApps/_ItemMenu/components/ItemAppShell.svelte
+++ b/src/formApps/_ItemMenu/components/ItemAppShell.svelte
@@ -19,14 +19,10 @@
     export let item;
     export let itemFlags;
 
-    const doc = new TJSDocument(item);
-    $:
-    {
-    $doc;
-    $animation.label = $doc.name
-    }
+    const isValidDocument = item instanceof foundry.abstract.Document;
+    const doc = isValidDocument ? new TJSDocument(item) : null;
 
-    let aaFlags = itemFlags.autoanimations || {};
+    let aaFlags = itemFlags?.autoanimations || {};
 
     const { application } = getContext("#external");
     let newFlagData = foundry.utils.deepClone(aaFlags);
@@ -47,9 +43,19 @@
     if (!newFlagData.hasOwnProperty('version')) {
         newFlagData.version = Object.keys(flagMigrations.migrations).map((n) => Number(n)).reverse()[0]
     }
-    newFlagData.label = item.name;
+    newFlagData.label = item.name ?? item.label ?? "";
 
     let animation = new AnimationStore(newFlagData)
+
+    $:
+    {
+        if (doc) {
+            $doc;
+            $animation.label = $doc?.name ?? item?.name ?? item?.label ?? $animation.label;
+        } else if (item?.name || item?.label) {
+            $animation.label = item.name ?? item.label;
+        }
+    }
 
     // Application position store reference. Stores need to be a top level variable to be accessible for reactivity.
     const position = application.position;

--- a/src/formApps/_ItemMenu/components/category/CategoryControl.svelte
+++ b/src/formApps/_ItemMenu/components/category/CategoryControl.svelte
@@ -29,6 +29,7 @@
   setContext('animation-data', {animation, category: animation, idx: 0})
 
   export let item;
+  const documentLabel = item?.documentName === "Activity" ? "Activity" : "Item";
 
   const is5e = game.system.id === "dnd5e";
   const { application } = getContext("#external");
@@ -104,7 +105,7 @@
       class={!isEnabled ? "aa-disableOpacity" : ""}
     >
       <Slider
-        label={localize("autoanimations.menus.customize") + " " + "Item"}
+        label={localize("autoanimations.menus.customize") + " " + documentLabel}
         field="isCustomized"
       />
     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ function registerAAItemHooks() {
     })
 
         Hooks.on('getHeaderControlsApplicationV2', (sheet, buttons) => {
-        if(!["Item", "ActiveEffect"].includes(sheet.document?.documentName)) return;
+        if(!["Item", "ActiveEffect", "Activity"].includes(sheet.document?.documentName)) return;
         if (!game.user.isGM && game.settings.get("autoanimations", "hideFromPlayers")) {
             return;
         }
@@ -96,7 +96,7 @@ function registerAAItemHooks() {
                 if ((game.system.id === 'pf1' && document?.type === 'buff') || ((game.system.id === 'pf2e' || game.system.id === 'sf2e') && pf2eRuleTypes.includes(document?.type))) {
                     new AEMenuApp(document, {}).render(true, { focus: true });
                 } else {
-                    if(document.documentName === "Item") {
+                    if(document.documentName === "Item" || document.documentName === "Activity") {
                     new ItemMenuApp(document, {}).render(true, { focus: true });
                     }else if(document.documentName === "ActiveEffect") {
                         new AEMenuApp(document, {}).render(true, { focus: true });

--- a/src/system-support/aa-dnd5e.js
+++ b/src/system-support/aa-dnd5e.js
@@ -21,7 +21,7 @@ export function systemHooks() {
             criticalCheck(roll, item);
             const ammoItem = item?.parent?.items?.get(data?.ammoUpdate?.id) ?? null;
             const overrideNames = activity?.name && !["heal", "summon"].includes(activity?.name?.trim()) ? [activity.name] : [];
-            attackV2(await getRequiredData({item: item, actor: item.parent, roll: item, rollAttackHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, ammoItem, overrideNames, hit}));
+            attackV2(await getRequiredData({item: item, actor: item.parent, activity, roll: item, rollAttackHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, ammoItem, overrideNames, hit}));
         });
     Hooks.on("dnd5e.rollDamageV2", async (rolls, data) => {
             const roll = rolls[0];
@@ -34,7 +34,7 @@ export function systemHooks() {
             const item = activity?.item;
             criticalCheck(roll, item);
             const overrideNames = activity?.name && !["heal", "summon"].includes(activity?.name?.trim()) ? [activity.name] : [];
-            damageV2(await getRequiredData({hit: hit, item, actor: item.parent, roll: item, rollDamageHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, overrideNames, }));
+            damageV2(await getRequiredData({hit: hit, item, actor: item.parent, activity, roll: item, rollDamageHook: {item, roll}, spellLevel: roll?.data?.item?.level ?? void 0, overrideNames, }));
         });
     Hooks.on('dnd5e.postUseActivity', async (activity, usageConfig, results) => {
         if (activity?.description?.chatFlavor?.includes("[noaa]")) return;
@@ -43,7 +43,7 @@ export function systemHooks() {
             const options = results;
             const item = activity?.item;
             const overrideNames = activity?.name && !["heal", "summon"].includes(activity?.name?.trim()) ? [activity.name] : [];
-            useItem(await getRequiredData({item, actor: item.parent, roll: item, useItemHook: {item, config, options}, spellLevel: options?.flags?.dnd5e?.use?.spellLevel || void 0, overrideNames}));
+            useItem(await getRequiredData({item, actor: item.parent, activity, roll: item, useItemHook: {item, config, options}, spellLevel: options?.flags?.dnd5e?.use?.spellLevel || void 0, overrideNames}));
         });
         Hooks.on("dnd5e.preUseActivity", (activity, config) => {
         if (activity?.description?.chatFlavor?.includes("[noaa]")) return;
@@ -59,7 +59,7 @@ export function systemHooks() {
             if (activity?.description?.chatFlavor?.includes("[noaa]")) return;
             const item = activity?.item;
             const overrideNames = activity?.name && !["heal", "summon"].includes(activity?.name?.trim()) ? [activity.name] : [];
-            templateAnimation(await getRequiredData({item, templateData: template, roll: template, isTemplate: true, overrideNames}));
+            templateAnimation(await getRequiredData({item, activity, templateData: template, roll: template, isTemplate: true, overrideNames}));
         });
 }
 


### PR DESCRIPTION
## Summary
- Add A-A header button support for dnd5e **Activity** sheets (Application V2), opening the existing animation config UI from activity context.
- Pass `activity` through dnd5e AA workflow inputs (`rollAttackV2`, `rollDamageV2`, `postUseActivity`, and template flow) so resolver logic can read activity-level flags.
- Update animation resolution precedence to:
  1. ammunition
  2. activity
  3. item
  4. autorec fallback
- Guard item menu document handling for Activity pseudo-documents to avoid `TJSDocument` errors.
- Update customize label text to show `Activity` when the config is opened from an activity sheet.

## Manual testing
- Open an item sheet and an activity sheet; confirm A-A button appears and opens config in both places.
- Set conflicting animations on item/activity/ammo and verify precedence: ammo > activity > item.

## Notes
- I am not a Foundry developer. I made this to get this functionality working in my own game, and while I tested it and it appears to work, it should still receive normal maintainer code review.
- No release/workflow/repo-admin changes are included in this PR.