### PR TITLE
fix: extract itemId from chat message HTML for OSE spells

### DIFF
--- a/src/system-support/aa-ose.js
+++ b/src/system-support/aa-ose.js
@@ -6,8 +6,14 @@ export function systemHooks() {
     Hooks.on("createChatMessage", async (msg) => {
         if (msg.user.id !== game.user.id) { return };
 
+        let itemId = msg.flags?.ose?.itemId;
+        if (!itemId) {
+            const match = msg.content?.match(/data-item-id="([^"]+)"/);
+            itemId = match ? match[1] : null;
+        }
+
         let compiledData = await getRequiredData({
-            itemId: msg.flags?.ose?.itemId,
+            itemId: itemId,
             actorId: msg.speaker?.actor,
             tokenId: msg.speaker?.token,
             workflow: msg,


### PR DESCRIPTION
Bug Description
Previously, weapon animations triggered successfully for OSE but spell animations (both template-based and target-based) failed to trigger entirely. The console indicated that OSE spells were not being detected by the Automated Animations module.

Root Cause
When the Foundry createChatMessage hook triggers, the module extracts the itemId from the msg.flags.ose.itemId property. While the OSE system successfully explicitly flags this property for Weapon Attacks, it bypasses these message flags entirely when creating spell rolls (damage/formula), making the itemId flag undefined. Since this flag was missing, Automated Animations ignored the chat messages for spells.

Implementation
This PR patches src/system-support/aa-ose.js to add a secondary check. If msg.flags.ose.itemId is undefined or missing, the module will now gracefully fall back to matching the data-item-id property natively preserved by the OSE system directly inside the msg.content HTML string via a regex.

Changes included:

Updated systemHooks() within aa-ose.js to implement the HTML dataset fallback for item extraction.