### PR TITLE
Updated functions and namespace to work in V14

### DIFF
--- a/src/system-handlers/workflow-data.js
+++ b/src/system-handlers/workflow-data.js
@@ -182,11 +182,11 @@ export default class AAHandler {
             var x, x1, y, y1, d, r, segments = [], rdistance, distance;
             for (x = t1StartX; x < t1.document.width; x++) {
                 for (y = t1StartY; y < t1.document.height; y++) {
-                    const origin = new PIXI.Point(...canvas.grid.getCenter(Math.round(t1.document.x + (canvas.dimensions.size * x)), Math.round(t1.document.y + (canvas.dimensions.size * y))));
+                    const origin = new PIXI.Point(canvas.grid.getCenterPoint(Math.round(t1.document.x + (canvas.dimensions.size * x)), Math.round(t1.document.y + (canvas.dimensions.size * y))));
                     for (x1 = t2StartX; x1 < target.document.width; x1++) {
                         for (y1 = t2StartY; y1 < target.document.height; y1++) {
-                            const dest = new PIXI.Point(...canvas.grid.getCenter(Math.round(target.document.x + (canvas.dimensions.size * x1)), Math.round(target.document.y + (canvas.dimensions.size * y1))));
-                            const r = new Ray(origin, dest);
+                            const dest = new PIXI.Point(canvas.grid.getCenterPoint(Math.round(target.document.x + (canvas.dimensions.size * x1)), Math.round(target.document.y + (canvas.dimensions.size * y1))));
+                            const r = new foundry.canvas.geometry.Ray(origin, dest);
                             segments.push({ ray: r });
                         }
                     }
@@ -195,7 +195,7 @@ export default class AAHandler {
             if (segments.length === 0) {
                 return noResult;
             }
-            rdistance = segments.map(ray => canvas.grid.measureDistances([ray], { gridSpaces: true })[0]);
+            rdistance = segments.map(ray => canvas.grid.measurePath([ray], { gridSpaces: true })[0]);
             distance = rdistance[0];
             rdistance.forEach(d => {
                 if (d < distance)


### PR DESCRIPTION
With the new Version, getCenter got removed/replaced by getCenterPoint. The function is the same.

With the new Version, measureDistance got removed/replaced by measurePath. The function is the same.

With the new Version, Ray got moved to the new namespace foundry.canvas.geometry.Ray. The function is the same.

Tested in V14 Build 360 together with the Sequencer Dev Branch (not related with the Sequencer Project)
No other Issues/Warnings/Error were noticed while testing.