### PR TITLE
Fix detection of non-item attacks in daggerheart

### DIFF
--- a/src/system-support/aa-daggerheart.js
+++ b/src/system-support/aa-daggerheart.js
@@ -47,7 +47,7 @@ async function handleChatMessageCreation(msg, _options, _userId) {
    const item = actor?.items.get(itemId);
    if (!actor) {
       return console.warn(`Daggerheart Workflow: Could not find Actor (${actorUuid}) for ChatMessage.`, { msg });
-   } else if (!item && action) {
+   } else if (!item && !action) {
       return console.warn(`Daggerheart Workflow: Could not find Item (${itemId}) or action for ChatMessage.`, {
          msg,
          actor,


### PR DESCRIPTION
I'm starting to prep a daggerheart thing for real now and I realized I messed something up the last time I tweaked this.