### PR TITLE
Fix OSE spell item lookup from roll options

### DIFF
--- a/src/system-support/aa-ose.js
+++ b/src/system-support/aa-ose.js
@@ -6,7 +6,7 @@ export function systemHooks() {
     Hooks.on("createChatMessage", async (msg) => {
         if (msg.author?.id !== game.user.id) { return };
 
-        let itemId = msg.flags?.ose?.itemId;
+        let itemId = msg.flags?.ose?.itemId ?? msg.rolls?.[0]?.options?.itemId;
         if (!itemId) {
             const match = msg.content?.match(/data-item-id="([^"]+)"/);
             itemId = match ? match[1] : null;

--- a/test/system-support/aa-ose.test.js
+++ b/test/system-support/aa-ose.test.js
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import vm from "node:vm";
+
+test("OSE spell messages resolve the item ID from Foundry roll options", async () => {
+    let chatMessageHook;
+    let requiredData;
+
+    const context = vm.createContext({
+        game: { user: { id: "current-user" } },
+        Hooks: {
+            on(hook, callback) {
+                if (hook === "createChatMessage") chatMessageHook = callback;
+            },
+        },
+    });
+
+    const source = await readFile(new URL("../../src/system-support/aa-ose.js", import.meta.url), "utf8");
+    const oseModule = new vm.SourceTextModule(source, { context });
+    const dependencies = {
+        "../router/traffic-cop.js": { trafficCop() {} },
+        "../system-handlers/workflow-data.js": {
+            default: { async make() { return { item: { id: "spell-id" } }; } },
+        },
+        "./getRequiredData.js": {
+            async getRequiredData(data) {
+                requiredData = data;
+                return data;
+            },
+        },
+    };
+
+    await oseModule.link((specifier) => {
+        const exports = dependencies[specifier];
+        return new vm.SyntheticModule(Object.keys(exports), function () {
+            for (const [name, value] of Object.entries(exports)) this.setExport(name, value);
+        }, { context });
+    });
+    await oseModule.evaluate();
+    oseModule.namespace.systemHooks();
+
+    const message = {
+        author: { id: "current-user" },
+        flags: { ose: {} },
+        rolls: [{ options: { itemId: "spell-id" } }],
+        speaker: { actor: "actor-id", token: "token-id" },
+    };
+    Object.defineProperty(message, "user", {
+        get() { throw new Error("The migrated ChatMessage#user property was accessed"); },
+    });
+
+    await chatMessageHook(message);
+
+    assert.equal(
+        requiredData.itemId,
+        "spell-id",
+        "OSE spell item ID was not read from roll options",
+    );
+});


### PR DESCRIPTION
## Summary
- resolve OSE spell item IDs from Foundry roll options before falling back to chat HTML
- add focused regression coverage for the OSE chat hook
- verify the hook uses `ChatMessage#author` without accessing deprecated `ChatMessage#user`

## Tests
- `OPENSSL_CONF=/dev/null node --experimental-vm-modules test/system-support/aa-ose.test.js` (passed)
- `npm run build` could not start because npm and node_modules are unavailable in the checkout environment

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1013:start -->
### Verification

[Northset proof-of-pass receipt M-1013](https://northset-oss.github.io/verification-pilot/receipts/M-1013/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1013:end -->
