### PR TITLE
Allow other modules to stop A-A asynchronously

### DIFF
--- a/src/system-handlers/workflow-data.js
+++ b/src/system-handlers/workflow-data.js
@@ -20,6 +20,9 @@ export default class AAHandler {
         // Hook to signify the start of the A-A workflow;
         Hooks.callAll("AutomatedAnimations-WorkflowStart", clonedData, animationData);
 
+        // Let listeners veto asynchronously.
+        if (clonedData.deferrals?.length) await Promise.allSettled(clonedData.deferrals);
+
         // Can be added from the above Hook to stop the A-A workflow
         if (clonedData.stopWorkflow) {
             debug(`Animation Workflow was interrupted by an External Source`, clonedData )


### PR DESCRIPTION
One issue when combining multiple animation modules is that they often exist in their own space and cannot be reliably asked "will you run? ok, I will let you go / stop you for my own implementation." This allows that by other modules effectively hooking onto WorkflowStart like this:

```js
Hooks.on("AutomatedAnimations-WorkflowStart", (clonedData, animationData) => {
  if (!overrideEnabled() || !animationData) return;
  (clonedData.deferrals ??= []).push(
    asyncFunctionFromModule(clonedData.item, TIMEOUT)
      .then(fired => { if (fired) clonedData.stopWorkflow = true; })
  );
});
```